### PR TITLE
Updated dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "absurd": "~0.3.33",
     "minimist": "~1.1.0",
     "chalk": "~0.5.1",
-    "lodash": "~3.1.0"
+    "lodash": "~3.2.0"
   },
   "devDependencies": {
     "mocha": "~2.1.0",
-    "chai": "~1.10.0",
+    "chai": "~2.0.0",
     "sinon": "~1.12.2",
-    "sinon-chai": "~2.6.0",
+    "sinon-chai": "~2.7.0",
     "istanbul": "~0.3.5",
     "jshint": "~2.6.0",
     "coveralls": "~2.11.2"


### PR DESCRIPTION
Now that sinon-chai has been updated to support chai 2.0.0.