### PR TITLE
Changing how we do general configuration for Atomizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm install atomizer -g
 ### CLI
 
 ```
-atomizer -c|--config=<file> [-o|--outfile=<file>] [--help] [--verbose] [ [-R] files_to_parse ...]
+atomizer [-c|--config=<file>] [-o|--outfile=<file>] [--rtl] [--help] [--verbose] [ [-R] files_to_parse ...]
 ```
 
 Example:
@@ -41,11 +41,6 @@ atomizer -c config.js -R ./site/ > atomic.css
 var Atomizer = require('atomizer');
 
 var defaultConfig = {
-    'config': {
-        'namespace': '#atomic',
-        'start': 'left',
-        'end': 'right'
-    },
     "border": {
         "custom": [
             {

--- a/bin/atomizer
+++ b/bin/atomizer
@@ -17,11 +17,13 @@ var atomizer = require('../src/atomizer');
 var utils = require('../src/lib/utils');
 var _ = require('lodash');
 var content = '';
-var config; 
+var config = {}; 
 var parsedConfig = {};
 var recursive = false;
 
-var params = require('minimist')(process.argv.slice(2));
+var params = require('minimist')(process.argv.slice(2), { 
+    "boolean": ['rtl', 'help', 'verbose', 'R' ] 
+});
 
 function parseFiles (files, dir) {
     var classNames = [];
@@ -55,17 +57,18 @@ function parseFile (file, dir) {
 }
 
 if (process.argv.slice(2).length === 0 || params.help) {
-    var usage = ['usage:  ', process.title, ' -c|--config=<file> [-o|--outfile=<file>] [--help] [--verbose] [ [-R] files_to_parse ...]'].join(' ');
+    var usage = ['usage:  ', process.title, ' [-c|--config=<file>] [-o|--outfile=<file>] [--rtl] [--help] [--verbose] [ [-R] files_to_parse ...]'].join(' ');
     console.log(usage);
     return;
 }
 
-// TODO
+// TODO: Populate this with params passed in on the command line
 var options = {
-    require: []
+    namespace: params.n,
+    rtl: params.rtl
 }; 
 
-if (options.require.length > 0) {
+if (Array.isArray(options.require) && options.require.length > 0) {
     options.require = options.require.map(function (file) {
         return path.resolve(file);
     });
@@ -80,9 +83,6 @@ if (configFile) {
         return false;
     }
     config = require(path.resolve(configFile));
-} else {
-    throw new Error('Configuration file not provided.');
-    return false;
 }
 
 // Generate config from parsed src files

--- a/examples/basic-config.js
+++ b/examples/basic-config.js
@@ -1,15 +1,4 @@
 module.exports = {
-    'config': {
-        'namespace': '#atomic',
-        'start': 'left',
-        'end': 'right',
-        'breakPoints': {
-            'sm': '767px',
-            'md': '992px',
-            'lg': '1200px'
-        }
-    },
-
     // pattern
     'display': {
         'b': true

--- a/examples/example-config.js
+++ b/examples/example-config.js
@@ -1,20 +1,4 @@
 module.exports = {
-    'config': {
-        'namespace': '#atomic',
-        'start': 'left',
-        'end': 'right',
-        'defaults': {
-            'font-size': '16px',
-            'border-color': '#555',
-            'bleed-value': '-10px'
-        },
-        'breakPoints': {
-            'sm': '767px',
-            'md': '992px',
-            'lg': '1200px'
-        }
-    },
-
     // pattern
     'border-top': {
         'custom': [

--- a/examples/html/sample-0.html
+++ b/examples/html/sample-0.html
@@ -1,1 +1,1 @@
-<div class="D-ib Fz-13px P-10px Bdb-1 C-fff">Test</div>
+<div class="D-ib Fz-13px P-10px Bdb-1 C-fff Fl-start">Test</div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomizer",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "A tool for creating Atomic CSS, a collection of single purpose styling units for maximum reuse",
   "main": "./lib/atomic.js",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomizer",
-  "version": "2.0.0",
+  "version": "2.0.0-alpha.1",
   "description": "A tool for creating Atomic CSS, a collection of single purpose styling units for maximum reuse",
   "main": "./lib/atomic.js",
   "contributors": [

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -260,9 +260,9 @@ module.exports = {
 
         var atomicBuilder = new AtomicBuilder(rules, config, options);
         var build = atomicBuilder.getBuild();
-        if (!_.size(build)) {
-            throw new Error('Failed to generate CSS. The `build` object is empty.');
-        }
+        // if (!_.size(build)) {
+        //     throw new Error('Failed to generate CSS. The `build` object is empty.');
+        // }
 
         api.add(build);
 

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -260,9 +260,6 @@ module.exports = {
 
         var atomicBuilder = new AtomicBuilder(rules, config, options);
         var build = atomicBuilder.getBuild();
-        // if (!_.size(build)) {
-        //     throw new Error('Failed to generate CSS. The `build` object is empty.');
-        // }
 
         api.add(build);
 

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -235,7 +235,15 @@ module.exports = {
             minify: false,
             keepCamelCase: false,
             extCSS: '.css',
-            banner: ''
+            banner: '',
+            namespace: '#atomic',
+            rtl: false,
+            // TODO: Verify these are good defaults
+            breakPoints: {
+                'sm': '767px',
+                'md': '992px',
+                'lg': '1200px'
+            }
         }, options);
 
         if (!config) {
@@ -250,7 +258,7 @@ module.exports = {
             api.import(options.require);
         }
 
-        var atomicBuilder = new AtomicBuilder(rules, config);
+        var atomicBuilder = new AtomicBuilder(rules, config, options);
         var build = atomicBuilder.getBuild();
         if (!_.size(build)) {
             throw new Error('Failed to generate CSS. The `build` object is empty.');

--- a/tests/AtomicBuilder.js
+++ b/tests/AtomicBuilder.js
@@ -85,6 +85,21 @@ describe('AtomicBuilder', function () {
     });
 
     describe('loadOptions()', function () {
+        it('throws if objs param is empty', function () {
+            // execute and assert
+            expect(function () {
+                AtomicBuilder.prototype.loadOptions();
+            }).to.throw(Error);
+        });
+        it('throws if objs param is not an object', function () {
+            // execute and assert
+            expect(function () {
+                AtomicBuilder.prototype.loadOptions('foo');
+            }).to.throw(TypeError);
+            expect(function () {
+                AtomicBuilder.prototype.loadOptions([]);
+            }).to.throw(TypeError);
+        });
         it('throws if options has breakPoints key but it\'s not an object', function () {
             // execute and assert
             expect(function () {

--- a/tests/AtomicBuilder.js
+++ b/tests/AtomicBuilder.js
@@ -34,10 +34,11 @@ describe('AtomicBuilder', function () {
             // mock methods
             mock.expects('loadObjects').once();
             mock.expects('loadConfig').once();
+            mock.expects('loadOptions').once();
             mock.expects('run').once();
 
             // execute
-            atomicBuilder = new AtomicBuilder([], {});
+            atomicBuilder = new AtomicBuilder([], {}, {});
 
             // assert
             expect(atomicBuilder.build).to.deep.equal({});
@@ -76,10 +77,31 @@ describe('AtomicBuilder', function () {
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // execute
-            atomicBuilder = new AtomicBuilder(atomicObjs);
+            atomicBuilder = new AtomicBuilder(atomicObjs, {}, {});
 
             // assert
             expect(atomicBuilder.atomicObjs).to.deep.equal(atomicObjs);
+        });
+    });
+
+    describe('loadOptions()', function () {
+        it('throws if options has breakPoints key but it\'s not an object', function () {
+            // execute and assert
+            expect(function () {
+                AtomicBuilder.prototype.loadOptions({    
+                    breakPoints: []
+                });
+            }).to.throw(TypeError);
+        });
+        it('throws if options has a breakPoints object but does not have `sm`, `md` nor `lg` keys', function () {
+            // execute and assert
+            expect(function () {
+                AtomicBuilder.prototype.loadOptions({
+                    breakPoints: {
+                        foo: 'bar'
+                    }
+                });
+            }).to.throw(Error);
         });
     });
 
@@ -99,46 +121,8 @@ describe('AtomicBuilder', function () {
                 AtomicBuilder.prototype.loadConfig('foo');
             }).to.throw(TypeError);
         });
-        it('throws if config does not have a config key', function () {
-            // execute and assert
-            expect(function () {
-                AtomicBuilder.prototype.loadConfig({});
-            }).to.throw(TypeError);
-        });
-        it('throws if config has breakPoints key but it\'s not an object', function () {
-            // execute and assert
-            expect(function () {
-                AtomicBuilder.prototype.loadConfig({
-                    config: {
-                        breakPoints: []
-                    }
-                });
-            }).to.throw(TypeError);
-        });
-        it('throws if config has a breakPoints object but does not have `sm`, `md` nor `lg` keys', function () {
-            // execute and assert
-            expect(function () {
-                AtomicBuilder.prototype.loadConfig({
-                    config: {
-                        breakPoints: {
-                            foo: 'bar'
-                        }
-                    }
-                });
-            }).to.throw(Error);
-        });
         it('should store the config', function () {
             var config = {
-                'config': {
-                    'namespace': '#atomic',
-                    'start': 'left',
-                    'end': 'right',
-                    'defaults': {
-                        'font-size': '16px',
-                        'border-color': '#555',
-                        'bleed-value': '-10px'
-                    }
-                },
                 'font-weight': {
                     'n': true,
                     'b': true
@@ -147,20 +131,19 @@ describe('AtomicBuilder', function () {
 
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // execute
-            atomicBuilder = new AtomicBuilder({}, config);
+            atomicBuilder = new AtomicBuilder({}, config, {});
 
             // assert
             expect(atomicBuilder.configObj).to.deep.equal(config);
         });
         it('should store the `sm` breakPoint as mediaQuery', function () {
-            var config = {
-                config: {
-                    breakPoints: {
-                        sm: '200px'
-                    }
+            var options = {
+                breakPoints: {
+                    sm: '200px'
                 }
             };
             var expected = {
@@ -169,20 +152,19 @@ describe('AtomicBuilder', function () {
 
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadConfig');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // execute
-            atomicBuilder = new AtomicBuilder({}, config);
+            atomicBuilder = new AtomicBuilder({}, {}, options);
 
             // assert
             expect(atomicBuilder.mediaQueries).to.deep.equal(expected);
         });
         it('should store the `md` breakPoint as mediaQuery', function () {
-            var config = {
-                config: {
-                    breakPoints: {
-                        md: '300px'
-                    }
+            var options = {
+                breakPoints: {
+                    md: '300px'
                 }
             };
             var expected = {
@@ -191,20 +173,19 @@ describe('AtomicBuilder', function () {
 
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadConfig');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // execute
-            atomicBuilder = new AtomicBuilder({}, config);
+            atomicBuilder = new AtomicBuilder({}, {}, options);
 
             // assert
             expect(atomicBuilder.mediaQueries).to.deep.equal(expected);
         });
         it('should store the `lg` breakPoint as mediaQuery', function () {
-            var config = {
-                config: {
-                    breakPoints: {
-                        lg: '500px'
-                    }
+            var options = {
+                breakPoints: {
+                    lg: '500px'
                 }
             };
             var expected = {
@@ -213,22 +194,21 @@ describe('AtomicBuilder', function () {
 
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadConfig');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // execute
-            atomicBuilder = new AtomicBuilder({}, config);
+            atomicBuilder = new AtomicBuilder({}, {}, options);
 
             // assert
             expect(atomicBuilder.mediaQueries).to.deep.equal(expected);
         });
         it('should store all breakPoints as mediaQueries', function () {
-            var config = {
-                config: {
-                    breakPoints: {
-                        sm: '200px',
-                        md: '300px',
-                        lg: '500px'
-                    }
+            var options = {
+                breakPoints: {
+                    sm: '200px',
+                    md: '300px',
+                    lg: '500px'
                 }
             };
             var expected = {
@@ -242,7 +222,7 @@ describe('AtomicBuilder', function () {
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // execute
-            atomicBuilder = new AtomicBuilder({}, config);
+            atomicBuilder = new AtomicBuilder({}, {}, options);
 
             // assert
             expect(atomicBuilder.mediaQueries).to.deep.equal(expected);
@@ -254,7 +234,7 @@ describe('AtomicBuilder', function () {
     // -------------------------------------------------------
     describe('flush()', function () {
         it('should clean build object', function () {
-            var atomicBuilder = new AtomicBuilder([], {config: {}});
+            var atomicBuilder = new AtomicBuilder([], {}, {});
             // set something in the build
             atomicBuilder.build = {
                 '.foo': {
@@ -411,6 +391,7 @@ describe('AtomicBuilder', function () {
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadConfig');
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
             sinon.stub(AtomicBuilder.prototype, 'addCssRule', function (className, property, value, breakPoints) {
                 expect(value).to.equal(expectedValue);
@@ -437,6 +418,7 @@ describe('AtomicBuilder', function () {
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadConfig');
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // instantiation & setup
@@ -569,6 +551,7 @@ describe('AtomicBuilder', function () {
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadConfig');
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // instantiation & setup
@@ -628,6 +611,7 @@ describe('AtomicBuilder', function () {
                 // stub methods
                 sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                 sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                 sinon.stub(AtomicBuilder.prototype, 'run');
 
                 // execute
@@ -639,6 +623,7 @@ describe('AtomicBuilder', function () {
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadConfig');
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // instantiation & setup
@@ -668,6 +653,7 @@ describe('AtomicBuilder', function () {
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadConfig');
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
             sinon.stub(AtomicBuilder.prototype, 'addCssRule', function (className, property, value, breakPoints) {
                 expect(className).to.equal(expectedClassName);
@@ -696,6 +682,7 @@ describe('AtomicBuilder', function () {
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadConfig');
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // instantiation & setup
@@ -758,6 +745,7 @@ describe('AtomicBuilder', function () {
                 // stub methods
                 sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                 sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                 sinon.stub(AtomicBuilder.prototype, 'run');
                 sinon.stub(AtomicBuilder.prototype, 'placeConstants', function (str) {
                     return str;
@@ -799,6 +787,7 @@ describe('AtomicBuilder', function () {
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadConfig');
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
             sinon.stub(AtomicBuilder.prototype, 'placeConstants', function (str) {
                 return str;
@@ -826,6 +815,7 @@ describe('AtomicBuilder', function () {
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadConfig');
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
             sinon.stub(AtomicBuilder.prototype, 'placeConstants', function (str) {
                 return str;
@@ -886,77 +876,52 @@ describe('AtomicBuilder', function () {
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadConfig');
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // execute
             var atomicBuilder = new AtomicBuilder();
-            atomicBuilder.configObj = {
-                config: {
-                    start: 'foo',
-                    end: 'bar'
-                }
-            };
 
             // assert
             expect(atomicBuilder.placeConstants(123)).equal(123);
         });
-        it('returns the processed string if passed, with config.start set', function () {
+        it('returns the processed string if passed, in ltr mode', function () {
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadConfig');
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // execute
             var atomicBuilder = new AtomicBuilder();
-            atomicBuilder.configObj = {
-                config: {
-                    start: 'foo'
-                }
+            atomicBuilder.configObj = {};
+            atomicBuilder.optionsObj = { 
+                rtl: false
             };
 
             // assert
-            expect(atomicBuilder.placeConstants('test-$START')).equal('test-foo');
-            expect(atomicBuilder.placeConstants('test-$END')).equal('test-$END');
-            expect(atomicBuilder.placeConstants('test-$START-$END')).equal('test-foo-$END');
+            expect(atomicBuilder.placeConstants('test-$START')).equal('test-left');
+            expect(atomicBuilder.placeConstants('test-$END')).equal('test-right');
+            expect(atomicBuilder.placeConstants('test-$START-$END')).equal('test-left-right');
         });
-        it('returns the processed string if passed, with config.end set', function () {
+        it('returns the processed string if passed, in rtl mode', function () {
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadConfig');
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // execute
             var atomicBuilder = new AtomicBuilder();
-            atomicBuilder.configObj = {
-                config: {
-                    end: 'bar'
-                }
+            atomicBuilder.configObj = {};
+            atomicBuilder.optionsObj = { 
+                rtl: true
             };
 
             // assert
-            expect(atomicBuilder.placeConstants('test-$START')).equal('test-$START');
-            expect(atomicBuilder.placeConstants('test-$END')).equal('test-bar');
-            expect(atomicBuilder.placeConstants('test-$START-$END')).equal('test-$START-bar');
-        });
-        it('returns the processed string if passed, with both config.start and config.end set', function () {
-            // stub methods
-            sinon.stub(AtomicBuilder.prototype, 'loadConfig');
-            sinon.stub(AtomicBuilder.prototype, 'loadObjects');
-            sinon.stub(AtomicBuilder.prototype, 'run');
-
-            // execute
-            var atomicBuilder = new AtomicBuilder();
-            atomicBuilder.configObj = {
-                config: {
-                    start: 'foo',
-                    end: 'bar'
-                }
-            };
-
-            // assert
-            expect(atomicBuilder.placeConstants('test-$START')).equal('test-foo');
-            expect(atomicBuilder.placeConstants('test-$END')).equal('test-bar');
-            expect(atomicBuilder.placeConstants('test-$START-$END')).equal('test-foo-bar');
+            expect(atomicBuilder.placeConstants('test-$START')).equal('test-right');
+            expect(atomicBuilder.placeConstants('test-$END')).equal('test-left');
+            expect(atomicBuilder.placeConstants('test-$START-$END')).equal('test-right-left');
         });
     });
 
@@ -970,6 +935,7 @@ describe('AtomicBuilder', function () {
                 // stub methods
                 sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                 sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                 sinon.stub(AtomicBuilder.prototype, 'run');
 
                 // execute
@@ -981,6 +947,7 @@ describe('AtomicBuilder', function () {
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadConfig');
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // execute
@@ -991,6 +958,9 @@ describe('AtomicBuilder', function () {
                 }
             };
             atomicBuilder.configObj = {
+                'foo': true
+            };
+            atomicBuilder.optionsObj = {
                 'foo': true
             };
             var result = atomicBuilder.getBuild();
@@ -1002,6 +972,7 @@ describe('AtomicBuilder', function () {
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadConfig');
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // execute
@@ -1012,14 +983,14 @@ describe('AtomicBuilder', function () {
                 }
             };
             atomicBuilder.configObj = {
-                config: {
-                    namespace: '.baz'
-                },
                 'foo': true
+            };
+            atomicBuilder.optionsObj = {
+                namespace: '.baz'
             };
             var result = atomicBuilder.getBuild();
             var expected = {};
-            expected[atomicBuilder.configObj.config.namespace] = atomicBuilder.build;
+            expected[atomicBuilder.optionsObj.namespace] = atomicBuilder.build;
 
             // assert
             expect(result).to.deep.equal(expected);
@@ -1036,6 +1007,7 @@ describe('AtomicBuilder', function () {
                 // stub methods
                 sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                 sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                 sinon.stub(AtomicBuilder.prototype, 'run');
 
                 // instantiation & setup
@@ -1055,6 +1027,7 @@ describe('AtomicBuilder', function () {
                 // stub methods
                 sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                 sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                 sinon.stub(AtomicBuilder.prototype, 'run');
 
                 // instantiation & setup
@@ -1076,6 +1049,7 @@ describe('AtomicBuilder', function () {
                 // stub methods
                 sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                 sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                 sinon.stub(AtomicBuilder.prototype, 'run');
 
                 // instantiation & setup
@@ -1097,6 +1071,7 @@ describe('AtomicBuilder', function () {
                 // stub methods
                 sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                 sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                 sinon.stub(AtomicBuilder.prototype, 'run');
 
                 // instantiation & setup
@@ -1118,6 +1093,7 @@ describe('AtomicBuilder', function () {
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadConfig');
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // instantiation & setup
@@ -1155,6 +1131,7 @@ describe('AtomicBuilder', function () {
                 // stub methods
                 sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                 sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                 sinon.stub(AtomicBuilder.prototype, 'run');
 
                 // instantiation & setup
@@ -1193,6 +1170,7 @@ describe('AtomicBuilder', function () {
                     // stub methods
                     sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                     sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                    sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                     sinon.stub(AtomicBuilder.prototype, 'run');
 
                     // instantiation & setup
@@ -1219,6 +1197,7 @@ describe('AtomicBuilder', function () {
                     // stub methods
                     sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                     sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                    sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                     sinon.stub(AtomicBuilder.prototype, 'run');
 
                     // instantiation & setup
@@ -1247,6 +1226,7 @@ describe('AtomicBuilder', function () {
                 // stub methods
                 sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                 sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                 sinon.stub(AtomicBuilder.prototype, 'run');
 
                 // instantiation & setup
@@ -1284,6 +1264,7 @@ describe('AtomicBuilder', function () {
                 // stub methods
                 sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                 sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                 sinon.stub(AtomicBuilder.prototype, 'run');
 
                 // instantiation & setup
@@ -1327,6 +1308,7 @@ describe('AtomicBuilder', function () {
                     // stub methods
                     sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                     sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                    sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                     sinon.stub(AtomicBuilder.prototype, 'run');
 
                     // instantiation & setup
@@ -1365,6 +1347,7 @@ describe('AtomicBuilder', function () {
                     // stub methods
                     sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                     sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                    sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                     sinon.stub(AtomicBuilder.prototype, 'run');
 
                     // instantiation & setup
@@ -1401,6 +1384,7 @@ describe('AtomicBuilder', function () {
                 // stub methods
                 sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                 sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                 sinon.stub(AtomicBuilder.prototype, 'run');
 
                 // instantiation & setup
@@ -1444,6 +1428,7 @@ describe('AtomicBuilder', function () {
                     // stub methods
                     sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                     sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                    sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                     sinon.stub(AtomicBuilder.prototype, 'run');
 
                     // instantiation & setup
@@ -1482,6 +1467,7 @@ describe('AtomicBuilder', function () {
                     // stub methods
                     sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                     sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                    sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                     sinon.stub(AtomicBuilder.prototype, 'run');
 
                     // instantiation & setup
@@ -1520,6 +1506,7 @@ describe('AtomicBuilder', function () {
                     // stub methods
                     sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                     sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                    sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                     sinon.stub(AtomicBuilder.prototype, 'run');
 
                     // instantiation & setup
@@ -1559,6 +1546,7 @@ describe('AtomicBuilder', function () {
                 // stub methods
                 sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                 sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                 sinon.stub(AtomicBuilder.prototype, 'run');
                 sinon.stub(AtomicBuilder.prototype, 'addPatternRule', function (rule) {
                     switch(rule.values[0]) {
@@ -1639,6 +1627,7 @@ describe('AtomicBuilder', function () {
                     // stub methods
                     sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                     sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                    sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                     sinon.stub(AtomicBuilder.prototype, 'run');
 
                     // instantiation & setup
@@ -1664,6 +1653,7 @@ describe('AtomicBuilder', function () {
                     // stub methods
                     sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                     sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                    sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                     sinon.stub(AtomicBuilder.prototype, 'run');
 
                     // instantiation & setup
@@ -1688,6 +1678,7 @@ describe('AtomicBuilder', function () {
                 // stub methods
                 sinon.stub(AtomicBuilder.prototype, 'loadConfig');
                 sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+                sinon.stub(AtomicBuilder.prototype, 'loadOptions');
                 sinon.stub(AtomicBuilder.prototype, 'run');
 
                 // instantiation & setup

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -29,13 +29,6 @@ describe('createCss()', function () {
             atomizer.createCSS();
         }).to.throw(Error);
     });
-    it ('throws if a config has been passed but with not enough info', function () {
-        expect(function () {
-            atomizer.createCSS({
-                'config': {}
-            });
-        }).to.throw(Error);
-    });
     it ('imports different absurdjs objects if passed as an option', function () {
         var result = atomizer.createCSS(defaultConfig, {
             require: [__dirname + '/fixtures/fz.js']

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -11,18 +11,7 @@ var defaultConfig;
 
 describe('createCss()', function () {
     beforeEach(function () {
-        defaultConfig = {
-            'config': {
-                'namespace': '#atomic',
-                'start': 'left',
-                'end': 'right',
-                'breakPoints': {
-                    'sm': '767px',
-                    'md': '992px',
-                    'lg': '1200px'
-                }
-            }
-        };
+        defaultConfig = {};
     });
     it ('throws if no configuration is provided', function () {
         expect(function () {
@@ -163,6 +152,18 @@ describe('createCss()', function () {
 
         expect(result).to.equal(expected);
     });
+    // it ('should throw if there\'s nothing to transform into CSS', function () {
+    //     var result;
+    //     var config = {
+    //         display: {
+    //             b: false
+    //         }
+    //     };
+
+    //     expect(function () {
+    //         atomizer.createCSS(config, { namespace: '' });
+    //     }).to.throw(Error);
+    // });
 });
 
 describe('parse()', function () {


### PR DESCRIPTION
Here's some big changes to how we configure Atomizer.  The gist is:

* No longer passing a `config` section in the config file.  Now those values are all passed via `options` in the Atomizer lib.  The Atomizer lib has default values for these options, and the CLI will expose these options soon (issue #66)
* `start` and `end` options are removed in favor of a new option called `rtl` (a boolean).  Based on the value of `rtl`, we'll replace the start and end tokens appropriately.
* Removed unused `defaults` config/option
