### PR TITLE
[WIP] Pseudos and Breakpoints

### DIFF
--- a/examples/basic-config.js
+++ b/examples/basic-config.js
@@ -1,13 +1,17 @@
 module.exports = {
     // pattern
     'display': {
-        'b': true
+        'b:f': true
     },
 
     // pattern
     'border-top': {
         custom: [
-            {suffix: '1', values: ['1px solid #ccc']}
+            {suffix: '1', values: ['1px solid #ccc']},
+            {suffix: '1--sm', values: ['1px solid #ccc']},
+            {suffix: '2--lg', values: ['2px solid #ccc']},
+            {suffix: 'foo:f', values: ['2px solid #ccc']},
+            {suffix: 'foo:f--sm', values: ['2px solid #ccc']}
         ]
     }
 };

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -253,9 +253,9 @@ module.exports = {
             rtl: false,
             // TODO: Verify these are good defaults
             breakPoints: {
-                'sm': '767px',
-                'md': '992px',
-                'lg': '1200px'
+                'sm': '@media(min-width:767px)',
+                'md': '@media(min-width:992px)',
+                'lg': '@media(min-width:1200px)'
             }
         }, options);
 

--- a/tests/AtomicBuilder.js
+++ b/tests/AtomicBuilder.js
@@ -158,7 +158,7 @@ describe('AtomicBuilder', function () {
         it('should store the `sm` breakPoint as mediaQuery', function () {
             var options = {
                 breakPoints: {
-                    sm: '200px'
+                    sm: '@media(min-width:200px)'
                 }
             };
             var expected = {
@@ -179,7 +179,7 @@ describe('AtomicBuilder', function () {
         it('should store the `md` breakPoint as mediaQuery', function () {
             var options = {
                 breakPoints: {
-                    md: '300px'
+                    md: '@media(min-width:300px)'
                 }
             };
             var expected = {
@@ -200,7 +200,7 @@ describe('AtomicBuilder', function () {
         it('should store the `lg` breakPoint as mediaQuery', function () {
             var options = {
                 breakPoints: {
-                    lg: '500px'
+                    lg: '@media(min-width:500px)'
                 }
             };
             var expected = {
@@ -221,9 +221,9 @@ describe('AtomicBuilder', function () {
         it('should store all breakPoints as mediaQueries', function () {
             var options = {
                 breakPoints: {
-                    sm: '200px',
-                    md: '300px',
-                    lg: '500px'
+                    sm: '@media(min-width:200px)',
+                    md: '@media(min-width:300px)',
+                    lg: '@media(min-width:500px)'
                 }
             };
             var expected = {
@@ -771,9 +771,9 @@ describe('AtomicBuilder', function () {
 
                 // add mediaQueries
                 atomicBuilder.mediaQueries = {
-                    sm: '@media(min-width:100px)',
-                    md: '@media(min-width:200px)',
-                    lg: '@media(min-width:300px)'
+                    sm: '100px',
+                    md: '200px',
+                    lg: '300px'
                 };
                 atomicBuilder.addCssRule(className, property, value, ['invalidbp']);
             }).to.throw(Error);
@@ -819,6 +819,56 @@ describe('AtomicBuilder', function () {
             };
 
             expect(atomicBuilder.addCssRule(className, property, value, breakPoints)).to.be.true;
+            expect(atomicBuilder.build).to.deep.equal(expected);
+        });
+        it('adds breakPoint rules if breakPoints AND pseudos have been passed in the suffix', function () {
+            var expected = {
+                '.Foo\\:active': {
+                    ':active': {
+                        'font-weight': 'bold'
+                    }
+                },
+                '.Foo\\:h': {
+                    ':hover': {
+                        'font-weight': 'bold'
+                    }
+                },
+                '.Foo--sm': {
+                    '@media(min-width:100px)': {
+                        'font-weight': 'bold'
+                    }
+                },
+                '.Foo\\:h--sm': {
+                    '@media(min-width:100px)': {
+                        ':hover': {
+                            'font-weight': 'bold'
+                        }
+                    }
+                }
+            };
+            // stub methods
+            sinon.stub(AtomicBuilder.prototype, 'loadConfig');
+            sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
+            sinon.stub(AtomicBuilder.prototype, 'run');
+            sinon.stub(AtomicBuilder.prototype, 'placeConstants', function (str) {
+                return str;
+            });
+
+            // execute
+            var atomicBuilder = new AtomicBuilder();
+
+            // add mediaQueries
+            atomicBuilder.mediaQueries = {
+                sm: '@media(min-width:100px)',
+                md: '@media(min-width:200px)',
+                lg: '@media(min-width:300px)'
+            };
+
+            expect(atomicBuilder.addCssRule('.Foo:h', property, value)).to.be.true;
+            expect(atomicBuilder.addCssRule('.Foo:active', property, value)).to.be.true;
+            expect(atomicBuilder.addCssRule('.Foo--sm', property, value)).to.be.true;
+            expect(atomicBuilder.addCssRule('.Foo:h--sm', property, value)).to.be.true;
             expect(atomicBuilder.build).to.deep.equal(expected);
         });
         it('adds rule if all params are valid and `breakPoints` has not been passed', function () {

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -103,6 +103,57 @@ describe('createCss()', function () {
 
         expect(result).to.equal(expected);
     });
+    it ('should return pseudo-classes and breakpoints if they are specified in the suffix', function () {
+        var result;
+        var config = {
+            display: {
+                b: {
+                    breakPoints: ['sm', 'md']
+                }
+            },
+            'padding-end': {
+                custom: [
+                    {suffix: 'foo', values: ['10px'], breakPoints: ['sm', 'md', 'lg']}
+                ]
+            }
+        };
+        var expected = [
+            '#atomic .D-b {',
+            '  display: block;',
+            '}',
+            '#atomic .Pend-foo {',
+            '  padding-right: 10px;',
+            '}',
+            '@media(min-width:767px) {',
+            '  #atomic .D-b--sm {',
+            '    display: block;',
+            '  }',
+            '  #atomic .Pend-foo--sm {',
+            '    padding-right: 10px;',
+            '  }',
+            '}',
+            '@media(min-width:992px) {',
+            '  #atomic .D-b--md {',
+            '    display: block;',
+            '  }',
+            '  #atomic .Pend-foo--md {',
+            '    padding-right: 10px;',
+            '  }',
+            '}',
+            '@media(min-width:1200px) {',
+            '  #atomic .Pend-foo--lg {',
+            '    padding-right: 10px;',
+            '  }',
+            '}',
+            ''
+        ].join('\n');
+
+        config = objectAssign(defaultConfig, config);
+
+        result = atomizer.createCSS(config);
+
+        expect(result).to.equal(expected);
+    });
     it ('should return rules in the same order they were declared in rules.js even if config was declared in a different order', function () {
         var result;
         var config = {


### PR DESCRIPTION
   * Added support for pseudos and breakpoints in custom suffixes;
   * BreakPoints config now requires a media-query declaration instead of just a number (See issue #71);
   * Custom BreakPoints can be declared;

Still could not figure out a good way to do pseudos for non-custom suffixes.

```
{
    display: {
        b: true,
        'b:h': true
    }
}
```

`b:h` is the ideal here but it makes my search in the config inefficient since I'm checking if the rule exist just by looking at the hash table for a valid keyword (in this case `b`). Is there a good way to look for the key in the hash table with the variant `b:h`?

@src-code thoughts?