### PR TITLE
Merge configs fix

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -175,7 +175,7 @@ module.exports = {
      * @return {object} An atomizer config object
      */
     mergeConfigs: function (configs) {
-        return Array.isArray(configs) && configs.length > 0 ? _.merge.apply(null, configs.concat(utils.handleMergeArrays)) : {};
+        return _.isArray(configs) && configs.length > 0 ? _.merge.apply(null, configs.concat(utils.handleMergeArrays)) : {};
     },
 
     /**

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -175,7 +175,7 @@ module.exports = {
      * @return {object} An atomizer config object
      */
     mergeConfigs: function (configs) {
-        return _.merge.apply(null, configs.concat(utils.handleMergeArrays));
+        return Array.isArray(configs) && configs.length > 0 ? _.merge.apply(null, configs.concat(utils.handleMergeArrays)) : {};
     },
 
     /**

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -368,4 +368,12 @@ describe('mergeConfigs()', function () {
 
         expect(config).to.deep.equal(expectedConfig);
     });
+    it('should return an empty object if argument is not an array', function () {
+        var config = atomizer.mergeConfigs();
+        expect(config).to.deep.equal({});
+    });
+    it('should return an empty object if argument is an empty array', function () {
+        var config = atomizer.mergeConfigs([]);
+        expect(config).to.deep.equal({});
+    });
 });


### PR DESCRIPTION
@src-code 

mergeConfigs() should return an empty object if argument is not an array or if it's an empty array