### PR TITLE
Changing breakPoints to be configured via config rather than as options

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,21 @@ atomizer -c config.js > atomic.css
 var Atomizer = require('atomizer');
 
 var defaultConfig = {
+    "breakPoints": {
+        'sm': '750px',
+        'md': '1000px',
+        'lg': '1200px'
+    },
     "border": {
         "custom": [
             {
                 "suffix": "1",
                 "values": [ "1px solid #000" ]
+            },
+            {
+                "suffix": "foo",
+                "values": [ "2px dotted #f00" ],
+                "breakPoints": ['sm', 'md']
             }
         ]
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomizer",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "A tool for creating Atomic CSS, a collection of single purpose styling units for maximum reuse",
   "main": "./lib/atomic.js",
   "contributors": [

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -240,6 +240,12 @@ module.exports = {
      */
     createCSS: function (config, options) {
         var content;
+        // TODO: Verify these are good defaults
+        var breakPoints = {
+            'sm': '767px',
+            'md': '992px',
+            'lg': '1200px'
+        };
 
         options = objectAssign({}, {
             require: [],
@@ -250,17 +256,16 @@ module.exports = {
             extCSS: '.css',
             banner: '',
             namespace: '#atomic',
-            rtl: false,
-            // TODO: Verify these are good defaults
-            breakPoints: {
-                'sm': '767px',
-                'md': '992px',
-                'lg': '1200px'
-            }
+            rtl: false
         }, options);
 
         if (!config) {
             throw new Error('No configuration provided.');
+        }
+
+        // Set defaults
+        if (!config.breakPoints) {
+            config.breakPoints = breakPoints;
         }
 
         var api = Absurd();

--- a/src/lib/AtomicBuilder.js
+++ b/src/lib/AtomicBuilder.js
@@ -61,6 +61,21 @@ AtomicBuilder.prototype.loadConfig = function (config) {
     if (config.constructor !== Object) {
         throw new TypeError('The `config` param must be an Object.');
     }
+    if (config.breakPoints) {
+        if (config.breakPoints.constructor !== Object) {
+            throw new TypeError('`config.breakPoints` must be an Object');
+        }
+        this.mediaQueries = {};
+        if (config.breakPoints.sm) {
+            this.mediaQueries.sm = '@media(min-width:' + config.breakPoints.sm + ')';
+        }
+        if (config.breakPoints.md) {
+            this.mediaQueries.md = '@media(min-width:' + config.breakPoints.md + ')';
+        }
+        if (config.breakPoints.lg) {
+            this.mediaQueries.lg = '@media(min-width:' + config.breakPoints.lg + ')';
+        }
+    }
     this.configObj = config;
 };
 
@@ -76,26 +91,6 @@ AtomicBuilder.prototype.loadOptions = function (options) {
     }
     if (options.constructor !== Object) {
         throw new TypeError('The `options` param must be an Object.');
-    }
-    if (options.breakPoints) {
-        if (options.breakPoints.constructor !== Object) {
-            throw new TypeError('`options.breakPoints` must be an Object');
-        }
-        if (_.size(options.breakPoints) > 0) {
-            if (!options.breakPoints.sm && !options.breakPoints.md && !options.breakPoints.lg) {
-                throw new Error('`options.breakPoints` must be an Object containing at least one of the following keys: sm, md, lg.');
-            }
-            this.mediaQueries = {};
-            if (options.breakPoints.sm) {
-                this.mediaQueries.sm = '@media(min-width:' + options.breakPoints.sm + ')';
-            }
-            if (options.breakPoints.md) {
-                this.mediaQueries.md = '@media(min-width:' + options.breakPoints.md + ')';
-            }
-            if (options.breakPoints.lg) {
-                this.mediaQueries.lg = '@media(min-width:' + options.breakPoints.lg + ')';
-            }
-        }
     }
     this.optionsObj = options;
 };

--- a/tests/AtomicBuilder.js
+++ b/tests/AtomicBuilder.js
@@ -100,24 +100,6 @@ describe('AtomicBuilder', function () {
                 AtomicBuilder.prototype.loadOptions([]);
             }).to.throw(TypeError);
         });
-        it('throws if options has breakPoints key but it\'s not an object', function () {
-            // execute and assert
-            expect(function () {
-                AtomicBuilder.prototype.loadOptions({    
-                    breakPoints: []
-                });
-            }).to.throw(TypeError);
-        });
-        it('throws if options has a breakPoints object but does not have `sm`, `md` nor `lg` keys', function () {
-            // execute and assert
-            expect(function () {
-                AtomicBuilder.prototype.loadOptions({
-                    breakPoints: {
-                        foo: 'bar'
-                    }
-                });
-            }).to.throw(Error);
-        });
     });
 
     // -------------------------------------------------------
@@ -155,8 +137,25 @@ describe('AtomicBuilder', function () {
             // assert
             expect(atomicBuilder.configObj).to.deep.equal(config);
         });
+        it('should handle empty breakPoints', function () {
+            var config = {
+                breakPoints: {}
+            };
+            var expected = {};
+
+            // stub methods
+            sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
+            sinon.stub(AtomicBuilder.prototype, 'run');
+
+            // execute
+            atomicBuilder = new AtomicBuilder({}, config, {});
+
+            // assert
+            expect(atomicBuilder.mediaQueries).to.deep.equal(expected);
+        });
         it('should store the `sm` breakPoint as mediaQuery', function () {
-            var options = {
+            var config = {
                 breakPoints: {
                     sm: '200px'
                 }
@@ -167,17 +166,17 @@ describe('AtomicBuilder', function () {
 
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
-            sinon.stub(AtomicBuilder.prototype, 'loadConfig');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // execute
-            atomicBuilder = new AtomicBuilder({}, {}, options);
+            atomicBuilder = new AtomicBuilder({}, config, {});
 
             // assert
             expect(atomicBuilder.mediaQueries).to.deep.equal(expected);
         });
         it('should store the `md` breakPoint as mediaQuery', function () {
-            var options = {
+            var config = {
                 breakPoints: {
                     md: '300px'
                 }
@@ -188,17 +187,17 @@ describe('AtomicBuilder', function () {
 
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
-            sinon.stub(AtomicBuilder.prototype, 'loadConfig');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // execute
-            atomicBuilder = new AtomicBuilder({}, {}, options);
+            atomicBuilder = new AtomicBuilder({}, config, {});
 
             // assert
             expect(atomicBuilder.mediaQueries).to.deep.equal(expected);
         });
         it('should store the `lg` breakPoint as mediaQuery', function () {
-            var options = {
+            var config = {
                 breakPoints: {
                     lg: '500px'
                 }
@@ -209,17 +208,17 @@ describe('AtomicBuilder', function () {
 
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
-            sinon.stub(AtomicBuilder.prototype, 'loadConfig');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // execute
-            atomicBuilder = new AtomicBuilder({}, {}, options);
+            atomicBuilder = new AtomicBuilder({}, config, {});
 
             // assert
             expect(atomicBuilder.mediaQueries).to.deep.equal(expected);
         });
         it('should store all breakPoints as mediaQueries', function () {
-            var options = {
+            var config = {
                 breakPoints: {
                     sm: '200px',
                     md: '300px',
@@ -234,10 +233,11 @@ describe('AtomicBuilder', function () {
 
             // stub methods
             sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
             sinon.stub(AtomicBuilder.prototype, 'run');
 
             // execute
-            atomicBuilder = new AtomicBuilder({}, {}, options);
+            atomicBuilder = new AtomicBuilder({}, config, {});
 
             // assert
             expect(atomicBuilder.mediaQueries).to.deep.equal(expected);

--- a/tests/AtomicBuilder.js
+++ b/tests/AtomicBuilder.js
@@ -154,6 +154,21 @@ describe('AtomicBuilder', function () {
             // assert
             expect(atomicBuilder.mediaQueries).to.deep.equal(expected);
         });
+        it('throws if breakPoints is not an object', function () {
+            var config = {
+                breakPoints: 'foo'
+            };
+
+            // stub methods
+            sinon.stub(AtomicBuilder.prototype, 'loadObjects');
+            sinon.stub(AtomicBuilder.prototype, 'loadOptions');
+            sinon.stub(AtomicBuilder.prototype, 'run');
+
+            // execute and assert
+            expect(function () {
+                var atomicBuilder = new AtomicBuilder({}, config, {});
+            }).to.throw(TypeError);
+        });
         it('should store the `sm` breakPoint as mediaQuery', function () {
             var config = {
                 breakPoints: {


### PR DESCRIPTION
@renatoi As we discussed, breakPoints will now be configured via the `breakPoints` property on the config object rather than as options.  `atomizer.createCSS()` will continue to manage a default set of breakpoints however, which it will add to the config object if necessary.  In the future, we may want to enable alternative ways to specify breakpoints via the CLI options or grunt task options, but for now I'm leaving that TBD.