### PR TITLE
Updating tests for 100% coverage on reactors branch

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -226,6 +226,13 @@ Atomizer.prototype.getSyntax = function () {
                     GRAMMAR.FRACTION,
                 ')',
                 '|',
+                '(?<hex>',
+                    GRAMMAR.HEX,
+                    '(?!',
+                    GRAMMAR.UNIT,
+                    ')',
+                ')',
+                '|',
                 '(?<sign>',
                     GRAMMAR.SIGN,
                 ')?',
@@ -235,10 +242,6 @@ Atomizer.prototype.getSyntax = function () {
                 '(?<unit>',
                     GRAMMAR.UNIT,
                 ')?',
-                '|',
-                '(?<hex>',
-                    GRAMMAR.HEX,
-                ')',
                 '|',
                 '(?<named>',
                     GRAMMAR.NAMED,
@@ -384,9 +387,6 @@ Atomizer.prototype.getCss = function (classNames/*:string[]*/, config/*:Atomizer
         if (match.parentSep) {
             treeo.parentSep = match.parentSep;
         }
-        if (match.prop) {
-            treeo.prop = match.prop;
-        }
         if (match.value) {
             treeo.value = match.value;
         }
@@ -398,16 +398,10 @@ Atomizer.prototype.getCss = function (classNames/*:string[]*/, config/*:Atomizer
             treeo.value = Math.round(match.numerator / match.denominator * 100 * 10000) / 10000 + '%';
         }
         if (match.sign) {
-            treeo.sign = match.sign;
-        }
-        if (match.number) {
-            treeo.number = match.number;
-        }
-        if (match.unit) {
-            treeo.unit = match.unit;
+            treeo.value = treeo.value.replace(GRAMMAR.SIGN, '-');
         }
         if (match.hex) {
-            treeo.hex = match.hex;
+            treeo.value = '#' + match.hex;
         }
         if (match.named) {
             treeo.named = match.named;
@@ -537,7 +531,7 @@ Atomizer.prototype.getCss = function (classNames/*:string[]*/, config/*:Atomizer
     // if (options.morph) {
     //     api.morph(options.morph);
     // }
-    
+
     // if (options.require.length > 0) {
     //     api.import(options.require);
     // }

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -102,13 +102,19 @@ describe('Atomizer()', function () {
     describe('getCss()', function () {
         it ('returns css by reading an array of class names', function () {
             var atomizer = new Atomizer();
-            var classNames = ['P-55px', 'H-100%', 'M-a', 'test:h>Op-1:h', 'Op-1'];
+            var classNames = ['P-55px', 'H-100%', 'M-a', 'test:h>Op-1:h', 'Op-1', 'C-333', 'Mt-neg10px'];
             var expected = [
+                '.C-333 {',
+                '  color: #333;',
+                '}',
                 '.H-100\\% {',
                 '  height: 100%;',
                 '}',
                 '.M-a {',
                 '  margin: auto;',
+                '}',
+                '.Mt-neg10px {',
+                '  margin-top: -10px;',
                 '}',
                 '.test:hover>.test\\:h\\>Op-1\\:h:hover, .Op-1 {',
                 '  opacity: 1;',
@@ -166,6 +172,9 @@ describe('Atomizer()', function () {
         it ('returns expected css value with breakpoints', function () {
             var atomizer = new Atomizer();
             var config = {
+                custom: {
+                    "foo": "10px"
+                },
                 breakPoints: {
                     sm: '@media(min-width:400px)'
                 }
@@ -175,9 +184,12 @@ describe('Atomizer()', function () {
                 '  .D-n--sm {',
                 '    display: none;',
                 '  }',
+                '  .P-foo--sm {',
+                '    padding: 10px;',
+                '  }',
                 '}\n'
             ].join('\n');
-            var result = atomizer.getCss(['D-n--sm'], config);
+            var result = atomizer.getCss(['D-n--sm', 'P-foo--sm'], config);
             expect(result).to.equal(expected);
         });
         it ('throws if breakpoints aren\'t valid', function () {
@@ -213,6 +225,28 @@ describe('Atomizer()', function () {
                 '}\n'
             ].join('\n');
             var result = atomizer.getCss(['C-brand-color'], config, {namespace: '#atomic'});
+            expect(result).to.equal(expected);
+        });
+        it ('ignores invalid classnames', function () {
+            var atomizer = new Atomizer();
+            var config = {};
+            var expected = '';
+            var result = atomizer.getCss(['XXXXX-1'], config);
+            expect(result).to.equal(expected);
+        });
+        it ('warns the user if an ambiguous class is provided and verbose flag is true', function (done) {
+            var atomizer = new Atomizer({verbose: true});
+            var config = {};
+            var expected = '';
+            // mock console.warn
+            console.temp = console.warn;
+            console.warn = function (text) {
+                var expected = "Class `C-foo` is ambiguous";
+                expect(text).to.contain(expected);
+                done();
+            };
+            var result = atomizer.getCss(['C-foo'], config);
+            console.warn = console.temp;
             expect(result).to.equal(expected);
         });
     });


### PR DESCRIPTION
Lots of new tests, plus fixes for hex and signed (eg `neg`) values.  

Please review regex changes in particular carefully.  I used a negated lookahead regex for hex values in order to ensure it does not match if the digits are followed by a unit, otherwise it would incorrectly think things like `P-100px` or `H-100%` were hex values.