### PR TITLE
Breaking out config merge into new getConfig() method

### DIFF
--- a/bin/atomizer
+++ b/bin/atomizer
@@ -102,8 +102,11 @@ if (filesToParse.length) {
     classnames = parseFiles(filesToParse, !!params.R);
 }
 
+// Finalize the config
+config = atomizer.getConfig(classnames, config);
+
 // Create the CSS
-content = atomizer.getCss(classnames, config, options);
+content = atomizer.getCss(config, options);
 
 // Output the CSS
 var outfile = params.o || params.outfile;

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -446,7 +446,12 @@ Atomizer.prototype.getCss = function (config/*:AtomizerConfig*/, options/*:CSSOp
             treeo.parentSep = match.parentSep;
         }
         if (match.value) {
-            treeo.value = match.value;
+            // is this a valid value?
+            if (rule.allowSuffixToValue) {
+                treeo.value = match.value;
+            } else {
+                match.named = match.value;
+            }
         }
         if (match.params) {
             treeo.params = match.params.split(',');

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -79,8 +79,8 @@ var GRAMMAR = {
     'UNIT'       : '[a-zA-Z%]+',
     'HEX'        : '[0-9a-f]{3}(?:[0-9a-f]{3})?',
     'IMPORTANT'  : '!',
-    // how do we deal with word boundary here?
-    'NAMED'      : '(.+?(?=--|!|:)|.+\\b)',
+    // https://regex101.com/r/mM2vT9/7
+    'NAMED'      : '(\\w+(?:(?:-(?!\\-))?\\w*)*)',
     'PSEUDO'     : PSEUDO_REGEX,
     'BREAKPOINT' : '--(?<breakPoint>[a-z]+)'
 };

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -325,10 +325,10 @@ Atomizer.prototype.findClassNames = function (src/*:string*/)/*:string[]*/ {
 };
 
 /**
- * Get CSS given an array of class names, a config and css options.
+ * Get Atomizer config given an array of class names and an optional config object
  * examples:
  *
- * getCss(['Op-1', 'D-n:h', 'Fz-heading'], {
+ * getConfig(['Op-1', 'D-n:h', 'Fz-heading'], {
  *     custom: {
  *         heading: '80px'
  *     },
@@ -342,9 +342,35 @@ Atomizer.prototype.findClassNames = function (src/*:string*/)/*:string[]*/ {
  *     rtl: true
  * });
  *
- * getCss(['Op-1', 'D-n:h']);
+ * getConfig(['Op-1', 'D-n:h']);
  */
-Atomizer.prototype.getCss = function (classNames/*:string[]*/, config/*:AtomizerConfig*/, options/*:CSSOptions*/)/*:string*/ {
+Atomizer.prototype.getConfig = function (classNames/*:string[]*/, config/*:AtomizerConfig*/)/*:AtomizerConfig*/ {
+    config = config || { classNames: [] };
+    // merge classnames with config
+    config.classNames = _.union(classNames || [], config.classNames);
+    return config;
+};
+
+/**
+ * Get CSS given an array of class names, a config and css options.
+ * examples:
+ *
+ * getCss({
+ *     custom: {
+ *         heading: '80px'
+ *     },
+ *     breakPoints: {
+ *         'sm': '@media(min-width:500px)',
+ *         'md': '@media(min-width:900px)',
+ *         'lg': '@media(min-width:1200px)'
+ *     },
+ *     classNames: ['D-b', 'Op-1', 'D-n:h', 'Fz-heading']
+ * }, {
+ *     rtl: true
+ * });
+ *
+ */
+Atomizer.prototype.getCss = function (config/*:AtomizerConfig*/, options/*:CSSOptions*/)/*:string*/ {
     var matches;
     var tree/*:AtomicTree*/ = {};
     var csso = {};
@@ -364,13 +390,6 @@ Atomizer.prototype.getCss = function (classNames/*:string[]*/, config/*:Atomizer
         rtl: false
     }, options);
 
-    classNames = classNames || [];
-
-    // merge classnames with config
-    if (config && config.classNames) {
-        classNames = _.union(classNames, config.classNames);
-    }
-
     // validate config.breakPoints
     if (config && config.breakPoints) {
         if (!_.isObject(config.breakPoints)) {
@@ -389,7 +408,7 @@ Atomizer.prototype.getCss = function (classNames/*:string[]*/, config/*:Atomizer
     }
 
     // each match is a valid class name
-    classNames.forEach(function (className) {
+    config.classNames.forEach(function (className) {
         var match = XRegExp.exec(className, syntaxRegex);
         var namedFound = false;
         var rule;

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -101,10 +101,52 @@ describe('Atomizer()', function () {
             expect(syntax).to.not.equal(result);
         });
     });
+    describe('getConfig()', function () {
+        it ('returns a valid config object when given classes and no config', function () {
+            var atomizer = new Atomizer();
+            var classNames = ['P-55px'];
+            var expected = {
+                classNames: ['P-55px']
+            };
+            var result = atomizer.getConfig(classNames);
+            expect(result).to.deep.equal(expected);
+
+            result = atomizer.getConfig(classNames, {});
+            expect(result).to.deep.equal(expected);
+        });
+        it ('returns a valid config object when given classes and existing config', function () {
+            var atomizer = new Atomizer();
+            var classNames = ['P-55px'];
+            var existingConfig = {
+                custom: {
+                    heading: '80px'
+                },
+                classNames: ['M-10px']
+            };
+            var expected = {
+                custom: {
+                    heading: '80px'
+                },
+                classNames: ['P-55px', 'M-10px']
+            };
+            var result = atomizer.getConfig(classNames, existingConfig);
+            expect(result).to.deep.equal(expected);
+        });
+        it ('returns a valid config object when given no arguments', function () {
+            var atomizer = new Atomizer();
+            var expected = {
+                classNames: []
+            };
+            var result = atomizer.getConfig();
+            expect(result).to.deep.equal(expected);
+        });
+    });
     describe('getCss()', function () {
         it ('returns css by reading an array of class names', function () {
             var atomizer = new Atomizer();
-            var classNames = ['P-55px', 'H-100%', 'M-a', 'test:h>Op-1:h', 'test:h_Op-1:h', 'Op-1', 'C-333', 'Mt-neg10px'];
+            var config = {
+                classNames: ['P-55px', 'H-100%', 'M-a', 'test:h>Op-1:h', 'test:h_Op-1:h', 'Op-1', 'C-333', 'Mt-neg10px']
+            };
             var expected = [
                 '.C-333 {',
                 '  color: #333;',
@@ -125,7 +167,7 @@ describe('Atomizer()', function () {
                 '  padding: 55px;',
                 '}\n'
             ].join('\n');
-            var result = atomizer.getCss(classNames);
+            var result = atomizer.getCss(config);
             expect(result).to.equal(expected);
         });
         it ('returns expected css of a helper class', function () {
@@ -142,7 +184,7 @@ describe('Atomizer()', function () {
                     },
                     rules: {
                         'rule': {
-                           'foo': 'bar'
+                            'foo': 'bar'
                         }
                     }
                 },
@@ -156,7 +198,9 @@ describe('Atomizer()', function () {
                     }
                 }
             ]);
-            var classNames = ['Foo(1,10px)', 'Bar()'];
+            var config = {
+                classNames: ['Foo(1,10px)', 'Bar()']
+            };
             var expected = [
                 'rule {',
                 '  foo: bar;',
@@ -169,11 +213,11 @@ describe('Atomizer()', function () {
                 '  bar: foo;',
                 '}\n'
             ].join('\n');
-            var result = atomizer.getCss(classNames);
+            var result = atomizer.getCss(config);
             expect(result).to.equal(expected);
         });
         it ('throws if helper class doesn\'t have a declaration', function () {
-            expect(function() {
+            expect(function () {
                 // set rules here so if helper change, we don't fail the test
                 var atomizer = new Atomizer(null, [
                     // empty
@@ -183,51 +227,26 @@ describe('Atomizer()', function () {
                         prefix: 'Bar'
                     }
                 ]);
-                var classNames = ['Bar()'];
-                atomizer.getCss(classNames);
+                var config = {
+                    classNames: ['Bar()']
+                };
+                atomizer.getCss(config);
             }).to.throw();
-        });
-        it ('returns expected css by reading an array of class names in config only', function () {
-            var atomizer = new Atomizer();
-            var config = {
-                classNames: ['P-55px', 'H-100%', 'M-a', 'test:h>Op-1:h', 'Op-1', 'W-1/3', 'Op-1!']
-            };
-            var expected = [
-                '.H-100\\% {',
-                '  height: 100%;',
-                '}',
-                '.M-a {',
-                '  margin: auto;',
-                '}',
-                '.test:hover>.test\\:h\\>Op-1\\:h:hover, .Op-1 {',
-                '  opacity: 1;',
-                '}',
-                '.Op-1\\! {',
-                '  opacity: 1 !important;',
-                '}',
-                '.P-55px {',
-                '  padding: 55px;',
-                '}',
-                '.W-1\\/3 {',
-                '  width: 33.3333%;',
-                '}\n'
-            ].join('\n');
-            var result = atomizer.getCss(null, config);
-            expect(result).to.equal(expected);
         });
         it ('returns expected css value declared in custom', function () {
             var atomizer = new Atomizer();
             var config = {
                 custom: {
                     'brand-color': '#400090'
-                }
+                },
+                classNames: ['C-brand-color', 'C-custom']
             };
             var expected = [
                 '.C-brand-color {',
                 '  color: #400090;',
                 '}\n'
             ].join('\n');
-            var result = atomizer.getCss(['C-brand-color', 'C-custom'], config);
+            var result = atomizer.getCss(config);
             expect(result).to.equal(expected);
         });
         it ('returns expected css value with breakpoints', function () {
@@ -270,7 +289,8 @@ describe('Atomizer()', function () {
                 },
                 breakPoints: {
                     sm: '@media(min-width:400px)'
-                }
+                },
+                classNames: ['D-n--sm', 'P-foo--sm', 'Foo()--sm', 'Bar(10px)--sm']
             };
             var expected = [
                 '@media(min-width:400px) {',
@@ -288,7 +308,7 @@ describe('Atomizer()', function () {
                 '  }',
                 '}\n'
             ].join('\n');
-            var result = atomizer.getCss(['D-n--sm', 'P-foo--sm', 'Foo()--sm', 'Bar(10px)--sm'], config);
+            var result = atomizer.getCss(config);
             expect(result).to.equal(expected);
         });
         it ('throws if breakpoints aren\'t valid', function () {
@@ -296,19 +316,21 @@ describe('Atomizer()', function () {
             var config = {
                 breakPoints: {
                     sm: '400px'
-                }
+                },
+                classNames: ['D-n--sm']
             };
             expect(function() {
-                atomizer.getCss(['D-n--sm'], config);
+                atomizer.getCss(config);
             }).to.throw();
         });
         it ('throws if breakpoints aren\'t passed as an object', function () {
             var atomizer = new Atomizer();
             var config = {
-                breakPoints: '400px'
+                breakPoints: '400px',
+                classNames: ['D-n--sm']
             };
             expect(function() {
-                atomizer.getCss(['D-n--sm'], config);
+                atomizer.getCss(config);
             }).to.throw();
         });
         it ('returns namespaced css when a namespace is specified in options', function () {
@@ -331,7 +353,8 @@ describe('Atomizer()', function () {
             var config = {
                 custom: {
                     'brand-color': '#400090'
-                }
+                },
+                classNames: ['C-brand-color', 'Foo()']
             };
             var expected = [
                 '#atomic .C-brand-color {',
@@ -341,19 +364,23 @@ describe('Atomizer()', function () {
                 '  font-weight: bold;',
                 '}\n'
             ].join('\n');
-            var result = atomizer.getCss(['C-brand-color', 'Foo()'], config, {namespace: '#atomic', helpersNS: '.atomic'});
+            var result = atomizer.getCss(config, {namespace: '#atomic', helpersNS: '.atomic'});
             expect(result).to.equal(expected);
         });
         it ('ignores invalid classnames', function () {
             var atomizer = new Atomizer();
-            var config = {};
+            var config = {
+                classNames: ['XXXXX-1']
+            };
             var expected = '';
-            var result = atomizer.getCss(['XXXXX-1'], config);
+            var result = atomizer.getCss(config);
             expect(result).to.equal(expected);
         });
         it ('warns the user if an ambiguous class is provided and verbose flag is true', function (done) {
             var atomizer = new Atomizer({verbose: true});
-            var config = {};
+            var config = {
+                classNames: ['C-foo']
+            };
             var expected = '';
             // mock console.warn
             console.temp = console.warn;
@@ -362,7 +389,7 @@ describe('Atomizer()', function () {
                 expect(text).to.contain(expected);
                 done();
             };
-            var result = atomizer.getCss(['C-foo'], config);
+            var result = atomizer.getCss(config);
             console.warn = console.temp;
             expect(result).to.equal(expected);
         });

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -116,18 +116,18 @@ describe('Atomizer()', function () {
         });
         it ('returns a valid config object when given classes and existing config', function () {
             var atomizer = new Atomizer();
-            var classNames = ['P-55px'];
+            var classNames = ['P-55px', 'D-b'];
             var existingConfig = {
                 custom: {
                     heading: '80px'
                 },
-                classNames: ['M-10px']
+                classNames: ['M-10px', 'D-ib']
             };
             var expected = {
                 custom: {
                     heading: '80px'
                 },
-                classNames: ['P-55px', 'M-10px']
+                classNames: ['P-55px', 'D-b', 'M-10px', 'D-ib']
             };
             var result = atomizer.getConfig(classNames, existingConfig);
             expect(result).to.deep.equal(expected);
@@ -250,6 +250,22 @@ describe('Atomizer()', function () {
             var expected = [
                 '.C-brand-color {',
                 '  color: #400090;',
+                '}\n'
+            ].join('\n');
+            var result = atomizer.getCss(config);
+            expect(result).to.equal(expected);
+        });
+        it ('returns expected css value declared in custom when using numeric keys', function () {
+            var atomizer = new Atomizer();
+            var config = {
+                custom: {
+                    '1': '10px solid #ccc'
+                },
+                classNames: ['Bdt-1']
+            };
+            var expected = [
+                '.Bdt-1 {',
+                '  border-top: 10px solid #ccc;',
                 '}\n'
             ].join('\n');
             var result = atomizer.getCss(config);

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -145,7 +145,7 @@ describe('Atomizer()', function () {
         it ('returns css by reading an array of class names', function () {
             var atomizer = new Atomizer();
             var config = {
-                classNames: ['P-55px', 'H-100%', 'M-a', 'test:h>Op-1:h', 'test:h_Op-1:h', 'Op-1', 'C-333', 'Mt-neg10px']
+                classNames: ['P-55px', 'H-100%', 'M-a', 'test:h>Op-1:h', 'test:h_Op-1:h', 'Op-1', 'Op-1!', 'C-333', 'Mt-neg10px', 'W-1/3']
             };
             var expected = [
                 '.C-333 {',
@@ -163,8 +163,14 @@ describe('Atomizer()', function () {
                 '.test:hover>.test\\:h\\>Op-1\\:h:hover, .test:hover .test\\:h_Op-1\\:h:hover, .Op-1 {',
                 '  opacity: 1;',
                 '}',
+                '.Op-1\\! {',
+                '  opacity: 1 !important;',
+                '}',
                 '.P-55px {',
                 '  padding: 55px;',
+                '}',
+                '.W-1\\/3 {',
+                '  width: 33.3333%;',
                 '}\n'
             ].join('\n');
             var result = atomizer.getCss(config);

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -30,8 +30,8 @@ describe('Atomizer()', function () {
         it('returns an array of valid atomic class names', function () {
             var atomizer = new Atomizer();
             // duplicate P-55px to make sure we get only one
-            var result = atomizer.findClassNames('<div class="P-55px P-55px H-100% test:h>Op-1:h test:test>Op-1"></div>');
-            var expected = ['P-55px', 'H-100%', 'test:h>Op-1:h'];
+            var result = atomizer.findClassNames('<div class="P-55px P-55px H-100% test:h>Op-1:h test:test>Op-1 C-the-best-border-color"></div>');
+            var expected = ['P-55px', 'H-100%', 'test:h>Op-1:h', 'C-the-best-border-color'];
             expect(result).to.deep.equal(expected);
         });
     });


### PR DESCRIPTION
Creating a new method called `getConfig()` so we can more easily build tools which output the complete config used to generate the CSS.

fyi @renatoi 