### PR TITLE
Added ability to pass prop+named in custom

### DIFF
--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -258,6 +258,26 @@ describe('Atomizer()', function () {
             var result = atomizer.getCss(config);
             expect(result).to.equal(expected);
         });
+        it ('returns expected css value declared in custom as prop + value', function () {
+            var atomizer = new Atomizer();
+            var config = {
+                custom: {
+                    'C-brand-color': '#400090',
+                    'Bgc-brand-color': '#000000'
+                },
+                classNames: ['C-brand-color', 'Bgc-brand-color']
+            };
+            var expected = [
+                '.Bgc-brand-color {',
+                '  background-color: #000000;',
+                '}',
+                '.C-brand-color {',
+                '  color: #400090;',
+                '}\n'
+            ].join('\n');
+            var result = atomizer.getCss(config);
+            expect(result).to.equal(expected);
+        });
         it ('returns expected css value declared in custom when using numeric keys', function () {
             var atomizer = new Atomizer();
             var config = {


### PR DESCRIPTION
@src-code @redonkulus @thierryk Now you'll be able to pass the prop + value identifier in ' custom', to contain the custom class to the property.

```
{
    custom: {
        'C-brand-color': '#400090',
        'Bgc-brand-color': '#000000'
    }
}
```

Note that it's not the class name you pass, but the property identifier + value identifier. This is important because if you use `C-brand-color:h`, you shouldn't pass that to custom, but `C-brand-color` only.