### PR TITLE
Fix pseudo class matching

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -66,7 +66,7 @@ for (var pseudo in PSEUDOS) {
     PSEUDO_REGEX.push(pseudo);
     PSEUDO_REGEX.push(PSEUDOS[pseudo]);
 }
-PSEUDO_REGEX = '(?:' + PSEUDO_REGEX.join('|') + ')';
+PSEUDO_REGEX = '(?:' + PSEUDO_REGEX.join('|') + ')(?![a-z])';
 
 // regular grammar to match valid atomic classes
 var GRAMMAR = {

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -145,7 +145,7 @@ describe('Atomizer()', function () {
         it ('returns css by reading an array of class names', function () {
             var atomizer = new Atomizer();
             var config = {
-                classNames: ['Ta-start', 'Ta-end', 'Bgc-#fff.4', 'Bgc-#fff', 'P-55px', 'H-100%', 'M-a', 'test:h>Op-1:h', 'test:h_Op-1:h', 'Op-1', 'Op-1!', 'D-n!', 'C-#333', 'Mt-neg10px', 'W-1/3']
+                classNames: ['Ta-start', 'Ta-end', 'Bgc-#fff.4', 'Bgc-#fff', 'P-55px', 'H-100%', 'M-a', 'test:h>Op-1:h', 'test:h_Op-1:h', 'Op-1', 'Op-1!', 'D-n!', 'C-#333', 'C-#333:li', 'Mt-neg10px', 'W-1/3']
             };
             var expected = [
                 '.Bgc-\\#fff\\.4 {',
@@ -154,7 +154,7 @@ describe('Atomizer()', function () {
                 '.Bgc-\\#fff {',
                 '  background-color: #fff;',
                 '}',
-                '.C-\\#333 {',
+                '.C-\\#333, .C-\\#333\\:li:link {',
                 '  color: #333;',
                 '}',
                 '.D-n\\! {',


### PR DESCRIPTION
Found an issue when using certain pseudo classes. For example, in the pseudo class regex the `:l` comes before the `:li` and the regex doesn't check if there are more characters after. So using `:li` gets matched with `:left`. Adding a negative lookahead check to make sure the full string is read. The test case can reproduce the issue without the fix.