### PR TITLE
Making 2nd arg to parseConfig() optional

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -501,6 +501,7 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
     var isVerbose = !!this.verbose;
 
     if (!_.isArray(config.classNames)) { return tree; }
+    options = options || {};
 
     config.classNames.forEach(function (className) {
         var match = XRegExp.exec(className, classNameSyntax);


### PR DESCRIPTION
@renatoi @thierryk 
This makes it easier to use the `parseConfig()` API outside of `getCss()` since we may not always need to pass options 