### PR TITLE
Fixing typo in name of "color"

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -715,7 +715,7 @@ module.exports = [
      */
     {
         type: 'pattern',
-        name: 'color',
+        name: 'Color',
         prefix: 'C',
         properties: ['color'],
         allowCustom: true,


### PR DESCRIPTION
Minor typo that's showing up in the docs reference page

@thierryk @renatoi 
