### PR TITLE
Revert LineClamp() fix

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -13,14 +13,9 @@ module.exports = [
                '-webkit-box-orient': 'vertical',
                'overflow': 'hidden'
             },
-            /**
-             * 1. fixes WebKit bug that displays an extra line when the pseudo-element
-             * is by itself on a next line
-             */
             'a[class*=LineClamp]': {
                'display': 'inline-block',
                'display': '-webkit-box',
-               'display': 'flex', /* 1 */
                '*display': 'inline',
                'zoom': 1
             },


### PR DESCRIPTION
It turns out the new syntax prevents the creation of ellipsis