### PR TITLE
cross browser user-select

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -2526,7 +2526,12 @@ module.exports = [
         "matcher": "Us",
         "allowParamToValue": false,
         "styles": {
-            "user-select": "$0"
+            "user-select": "$0",
+            "-webkit-touch-callout": "$0",
+            "-webkit-user-select": "$0",
+            "-khtml-user-select": "$0",
+            "-moz-user-select": "$0",
+            "-ms-user-select": "$0"
         },
         "arguments": [{
             "a": "all",


### PR DESCRIPTION
@thierryk @renatoi this needed to make `user-select` work in all browsers.