### PR TITLE
Allow numbers and letters [a-z0-9] on breakPoints

### DIFF
--- a/src/lib/grammar.js
+++ b/src/lib/grammar.js
@@ -66,7 +66,7 @@ var GRAMMAR = {
     'NAMED'         : '([\\w$]+(?:(?:-(?!\\-))?\\w*)*)',
     'PSEUDO'        : PSEUDO_REGEX,
     'PSEUDO_SIMPLE' : ':[a-z]+',
-    'BREAKPOINT'    : '--(?<breakPoint>[a-z]+)'
+    'BREAKPOINT'    : '--(?<breakPoint>[a-z0-9]+)'
 };
 
 GRAMMAR.PARENT_SELECTOR = [

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -549,9 +549,10 @@ describe('Atomizer()', function () {
                     "foo": "10px"
                 },
                 breakPoints: {
+                    '2xs': '@media(min-width:300px)',
                     sm: '@media(min-width:400px)'
                 },
-                classNames: ['D(n)--sm', 'P(foo)--sm', 'Foo--sm', 'Bar(10px)--sm']
+                classNames: ['D(n)--sm', 'P(foo)--sm', 'Foo--2xs', 'Bar(10px)--sm']
             };
             var expected = [
                 '@media(min-width:400px) {',
@@ -561,11 +562,13 @@ describe('Atomizer()', function () {
                 '  .P\\(foo\\)--sm {',
                 '    padding: 10px;',
                 '  }',
-                '  .Foo--sm {',
-                '    foo: bar;',
-                '  }',
                 '  .Bar\\(10px\\)--sm {',
                 '    bar: 10px;',
+                '  }',
+                '}\n',
+                '@media(min-width:300px) {',
+                '  .Foo--2xs {',
+                '    foo: bar;',
                 '  }',
                 '}\n'
             ].join('\n');

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -565,7 +565,7 @@ describe('Atomizer()', function () {
                 '  .Bar\\(10px\\)--sm {',
                 '    bar: 10px;',
                 '  }',
-                '}\n',
+                '}',
                 '@media(min-width:300px) {',
                 '  .Foo--2xs {',
                 '    foo: bar;',


### PR DESCRIPTION
@renatoi @thierryk we recently needed this feature for creating more breakpoints.

We where using the tshirt size format but we wanted to be able to add more breakpoints (e.g. 2xs, xs, sm, m...).