### PR TITLE
Adding rules for font-smooth/font-smoothing

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -1301,6 +1301,65 @@ module.exports = [
         }
     },
     /**
+    ==================================================================
+    FONT-SMOOTH
+    Warning: This feature is non-standard and varies by UA. Use with caution.
+    https://developer.mozilla.org/en-US/docs/Web/CSS/font-smooth
+    ==================================================================
+    */
+    {
+        'type': 'pattern',
+        'id': 'font-smooth',
+        'name': 'Font smoothing',
+        'matcher': 'Fsm',
+        'allowParamToValue': true,
+        'styles': {
+            'font-smooth': '$0'
+        },
+        'arguments': [
+            {
+                'a': 'auto',
+                'n': 'never',
+                'aw': 'always'
+            }
+        ]
+    },
+    {
+        'type': 'pattern',
+        'id': 'font-smooth-webkit',
+        'name': 'Font smoothing - Webkit',
+        'matcher': 'Fsmw',
+        'allowParamToValue': false,
+        'styles': {
+            '-webkit-font-smoothing': '$0'
+        },
+        'arguments': [
+            {
+                'n': 'none',
+                'a': 'antialiased',
+                's': 'subpixel-antialiased'
+            }
+        ]
+    },
+    {
+        'type': 'pattern',
+        'id': 'font-smooth-moz',
+        'name': 'Font smoothing - Mozilla',
+        'matcher': 'Fsmm',
+        'allowParamToValue': false,
+        'styles': {
+            '-moz-osx-font-smoothing': '$0'
+        },
+        'arguments': [
+            {
+                'a': 'auto',
+                'i': 'inherit',
+                'g': 'grayscale',
+                'u': 'unset'
+            }
+        ]
+    },
+    /**
      ==================================================================
      FONT-STYLE
      ==================================================================


### PR DESCRIPTION
Alright, we talked about this at one point and weren't sure we wanted to support a non-standard rule like `font-smooth`.  I've been running into some use cases lately where it's actually needed, and managing these rules apart from core Atomizer is a bit of a pain.  So I'm creating this PR to continue the discussion on whether Atomizer should have support baked in.  

@renatoi @thierryk Your thoughts?