### PR TITLE
Fixing findClassNames() string trim behavior

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -86,7 +86,7 @@ Atomizer.prototype.findClassNames = function (src/*:string*/)/*:string[]*/ {
 
     while (match !== null) {
         // strip boundary character
-        className = match[0].substr(1);
+        className = match[0].trim();
 
         // assign to classNamesObj as key and give it a counter
         classNamesObj[className] = (classNamesObj[className] || 0) + 1;

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -86,7 +86,7 @@ Atomizer.prototype.findClassNames = function (src/*:string*/)/*:string[]*/ {
 
     while (match !== null) {
         // strip boundary character
-        className = match[0].trim();
+        className = match[1];
 
         // assign to classNamesObj as key and give it a counter
         classNamesObj[className] = (classNamesObj[className] || 0) + 1;
@@ -183,7 +183,7 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
         rule = this.rules[ruleIndex];
 
         treeo = {
-            className: match[0],
+            className: match[1],
             declarations: _.cloneDeep(rule.styles)
         };
 

--- a/src/lib/grammar.js
+++ b/src/lib/grammar.js
@@ -181,6 +181,7 @@ Grammar.prototype.getSyntax = function getSyntax(isSimple)/*:string*/ {
     var syntax = [
         // word boundary
         GRAMMAR.BOUNDARY,
+        '(',
         // optional parent
         '(?<parentSelector>',
             isSimple ? GRAMMAR.PARENT_SELECTOR_SIMPLE : GRAMMAR.PARENT_SELECTOR,
@@ -197,7 +198,8 @@ Grammar.prototype.getSyntax = function getSyntax(isSimple)/*:string*/ {
         // optional modifier
         '(?:',
             GRAMMAR.BREAKPOINT,
-        ')?'
+        ')?',
+        ')'
     ].join('');
 
     return XRegExp(syntax, 'g');

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -36,6 +36,12 @@ describe('Atomizer()', function () {
             var expected = ['sibling:c+D(n)', 'Pos(r)', 'Ov(h)', 'H(0)', 'test:h>Op(1):h', 'test-open_Ov(v)', 'test-open_H(a)'];
             expect(result).to.deep.equal(expected);
         });
+        it('returns an array of valid atomic class names even if there\'s no boundary character for the first found classname', function () {
+            var atomizer = new Atomizer();
+            var result = atomizer.findClassNames("Pos(r) Ov(h) H(0)");
+            var expected = ['Pos(r)', 'Ov(h)', 'H(0)'];
+            expect(result).to.deep.equal(expected);
+        });
     });
     describe('addRules()', function () {
         it('throws if a rule with the same prefix already exists', function () {


### PR DESCRIPTION
Right now, if an Atomic classname is the first thing in a parsed file, `findClassNames()` improperly strips the first character of the classname because it assumes there should be a boundary character present.  

Switching to `trim()` seems like an easy fix, however I'm still not clear on why the regex is matching the boundary character in the first place.  It is probably better if we fix the regex to not return that char... @renatoi, any idea why this was necessary?