### PR TITLE
Adding ability to specify rules via the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Usage: atomizer [options] [path]
     -V, --version                       output the version number
     -R, --recursive                     process all files recursively in the path.
     -c, --config [file]                 source config file if any.
+    -r, --rules [file]                  custom rules file (argument may be passed multiple times)
     -o, --outfile [file]                destination config file.
     -n, --namespace [namespace]         adds the given namespace to all generated Atomic CSS selectors.
     -H, --helpersNamespace [namespace]  adds the given namespace to all helper selectors.

--- a/bin/atomizer
+++ b/bin/atomizer
@@ -30,7 +30,7 @@ program
   .usage('[options] [path]')
   .option('-R, --recursive', 'process all files recursively in the path')
   .option('-c, --config [file]', 'source config file')
-  .option('-r, --rules [file]', 'custom rules file', collect, [])
+  .option('-r, --rules [file]', 'custom rules file (argument may be passed multiple times)', collect, [])
   .option('-o, --outfile [file]', 'destination config file')
   .option('-n, --namespace [namespace]', 'adds the given namespace to all generated Atomic CSS selectors')
   .option('-H, --helpersNamespace [namespace]', 'adds the given namespace to all helper selectors')

--- a/bin/atomizer
+++ b/bin/atomizer
@@ -20,17 +20,23 @@ var content = '';
 var config = {};
 var classnames = [];
 
+function collect(val, memo) {
+  memo.push(val);
+  return memo;
+}
+
 program
   .version(JSON.parse(fs.readFileSync(__dirname + '/../package.json', 'utf8')).version)
   .usage('[options] [path]')
-  .option('-R, --recursive', 'process all files recursively in the path.')
-  .option('-c, --config [file]', 'source config file if any.')
-  .option('-o, --outfile [file]', 'destination config file.')
-  .option('-n, --namespace [namespace]', 'adds the given namespace to all generated Atomic CSS selectors.')
-  .option('-H, --helpersNamespace [namespace]', 'adds the given namespace to all helper selectors.')
-  .option('--rtl', 'swaps `start` and `end` keyword replacements with `right` and `left`.')
-  .option('--ie', 'adds old IE hacks to the output.')
-  .option('--verbose', 'show additional log info (warnings).')
+  .option('-R, --recursive', 'process all files recursively in the path')
+  .option('-c, --config [file]', 'source config file')
+  .option('-r, --rules [file]', 'custom rules file', collect, [])
+  .option('-o, --outfile [file]', 'destination config file')
+  .option('-n, --namespace [namespace]', 'adds the given namespace to all generated Atomic CSS selectors')
+  .option('-H, --helpersNamespace [namespace]', 'adds the given namespace to all helper selectors')
+  .option('--rtl', 'swaps `start` and `end` keyword replacements with `right` and `left`')
+  .option('--ie', 'adds old IE hacks to the output')
+  .option('--verbose', 'show additional log info (warnings)')
   .parse(process.argv);
 
 if (process.argv.length <= 2) {
@@ -93,6 +99,19 @@ if (typeof program.helpersNamespace !== 'undefined') {
 // Options: IE
 if (typeof program.ie !== 'undefined') {
     options.ie = true;
+}
+
+// Custom rulesets
+var rulesFiles = program.rules;
+if (rulesFiles) {
+    rulesFiles.forEach(function (rulesFile) {
+        if (!fs.existsSync(rulesFile)) {
+            throw new Error('Rule file ' + chalk.cyan(rulesFile) + ' not found.');
+            return false;
+        }
+        console.warn('Adding rules from ' + chalk.cyan(rulesFile) + '.');
+        atomizer.addRules(require(path.resolve(rulesFile)));
+    });
 }
 
 // Static config should contain the general 'config' options, along with any


### PR DESCRIPTION
```
$ atomizer 

  Usage: atomizer [options] [path]

  Options:

    -h, --help                          output usage information
    -V, --version                       output the version number
    -R, --recursive                     process all files recursively in the path
    -c, --config [file]                 source config file
    -r, --rules [file]                  custom rules file
    -o, --outfile [file]                destination config file
    -n, --namespace [namespace]         adds the given namespace to all generated Atomic CSS selectors
    -H, --helpersNamespace [namespace]  adds the given namespace to all helper selectors
    --rtl                               swaps `start` and `end` keyword replacements with `right` and `left`
    --ie                                adds old IE hacks to the output
    --verbose                           show additional log info (warnings)
```

Can specify multiple rule files by specifying multiple `-r` params:

```
atomizer -r ./rules1.js -r ./rules2.js my_file.html
```

FYI @renatoi 
