### PR TITLE
Clean up declaration placeholders for optional params

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -356,7 +356,12 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
                         treeo.declarations = null;
                     }
                 });
+                // If any of the arguments in the declaration weren't replaced, then we need to clean them up
+                if (treeo.declarations && treeo.declarations[prop] && treeo.declarations[prop].indexOf('$') >= 0) {
+                    treeo.declarations[prop] = treeo.declarations[prop].replace(/[,\s]?\$\d+/g, '');
+                }
             }
+
             // add important for the following cases:
             //    - `!` was used in the class name
             //    - rule has a parent class, a namespace was given and the rule is not a helper [1]

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -759,14 +759,14 @@ describe('Atomizer()', function () {
         it ('properly handles classnames with optional arguments', function () {
             var atomizer = new Atomizer();
             var config = {
-                classNames: ['Skew(90)', 'Skew(90,45)']
+                classNames: ['Skew(90deg)', 'Skew(90deg,45deg)']
             };
             var expected = [
-                '.Skew\\(90\\) {',
-                '  transform: skew(90);',
+                '.Skew\\(90deg\\) {',
+                '  transform: skew(90deg);',
                 '}',
-                '.Skew\\(90\\,45\\) {',
-                '  transform: skew(90,45);',
+                '.Skew\\(90deg\\,45deg\\) {',
+                '  transform: skew(90deg,45deg);',
                 '}\n'
             ].join('\n');
             var result = atomizer.getCss(config);

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -764,8 +764,8 @@ describe('Atomizer()', function () {
             var expected = [
                 '.Skew\\(90\\) {',
                 '  transform: skew(90);',
-                '}\n',
-                '.Skew\\(90,45\\) {',
+                '}',
+                '.Skew\\(90\\,45\\) {',
                 '  transform: skew(90,45);',
                 '}\n'
             ].join('\n');

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -756,6 +756,22 @@ describe('Atomizer()', function () {
             var result = atomizer.getCss(config);
             expect(result).to.equal(expected);
         });
+        it ('properly handles classnames with optional arguments', function () {
+            var atomizer = new Atomizer();
+            var config = {
+                classNames: ['Skew(90)', 'Skew(90,45)']
+            };
+            var expected = [
+                '.Skew\\(90\\) {',
+                '  transform: skew(90);',
+                '}\n',
+                '.Skew\\(90,45\\) {',
+                '  transform: skew(90,45);',
+                '}\n'
+            ].join('\n');
+            var result = atomizer.getCss(config);
+            expect(result).to.equal(expected);
+        });
     });
     // -------------------------------------------------------
     // escapeSelector()


### PR DESCRIPTION
Addressing issue #221.  

I considered a couple of different approaches to solve this.  One was to loop on placeholders rather than supplied params so we can more easily replace empty params, and detect when a classname fails to provide the expected number of params.  Even go a step further and have type checking... But in the end, I decided to keep this simple and retain the hands-off approach Atomizer currently employs, trusting the developer to pass the correct params, while simply cleaning up any stray placeholders that may not be used due to their optional nature.  That way we can at least produce valid CSS if valid params are supplied in the classname, whereas without this fix we can't.

If we think it's valuable to have stricter type checking in the future, I think we'll want to tackle that as a new issue.  But my gut tells me that's probably overkill.

@renatoi 