### PR TITLE
Add parsing support for class names following closing brace

### DIFF
--- a/src/lib/grammar.js
+++ b/src/lib/grammar.js
@@ -48,7 +48,7 @@ PSEUDO_REGEX = '(?:' + PSEUDO_REGEX.join('|') + ')(?![a-z])';
 
 // regular grammar to match valid atomic classes
 var GRAMMAR = {
-    'BOUNDARY'      : '(?:^|\\s|"|\'|\{)',
+    'BOUNDARY'      : '(?:^|\\s|"|\'|\{|\})',
     'PARENT'        : '[a-zA-Z][-_a-zA-Z0-9]+?',
     'PARENT_SEP'    : '[>_+]',
     // all characters allowed to be a prop

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -42,6 +42,12 @@ describe('Atomizer()', function () {
             var expected = ['Pos(r)', 'Ov(h)', 'H(0)'];
             expect(result).to.deep.equal(expected);
         });
+        it('properly finds Atomic classnames inside Dust template conditionals', function () {
+            var atomizer = new Atomizer();
+            var result = atomizer.findClassNames('<div class="Pos(r) Ov(h) H(0) {?foo}D(n){/foo}"></div>');
+            var expected = ['Pos(r)', 'Ov(h)', 'H(0)', 'D(n)'];
+            expect(result).to.deep.equal(expected);
+        });
     });
     describe('addRules()', function () {
         it('throws if a rule with a different definition already exists', function () {


### PR DESCRIPTION
@src-code I'm not sure if this is a valid use-case because (in theory) you could always replace the dust syntax in the example with conditional Atomic css.