### PR TITLE
Don't add !important if declarations is null

### DIFF
--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -370,7 +370,7 @@ Atomizer.prototype.parseConfig = function (config/*:AtomizerConfig*/, options/*:
             //     to give it extra specificity (to make sure it has more weight than normal atomic
             //     classes) we add important to them. Helper classes don't need it because they do
             //     not share the same namespace.
-            if (match.important || (match.parent && options.namespace && rule.type !== 'helper')) {
+            if (treeo.declarations && (match.important || (match.parent && options.namespace && rule.type !== 'helper'))) {
                 treeo.declarations[prop] += ' !important';
             }
         }


### PR DESCRIPTION
Erroring right now when a custom value is undefined... so we never see the warning, we just get a fatal.