### PR TITLE
Updating import of XRegExp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atomizer",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "A tool for creating Atomic CSS, a collection of single purpose styling units for maximum reuse",
   "main": "./src/atomizer.js",
   "contributors": [

--- a/src/atomizer.js
+++ b/src/atomizer.js
@@ -11,7 +11,7 @@ var utils = require('./lib/utils');
 var JSS = require('./lib/jss');
 var Grammar = require('./lib/grammar');
 var objectAssign = require('object-assign');
-var XRegExp = require('xregexp').XRegExp;
+var XRegExp = require('xregexp');
 
 var RULES = require('./rules.js').concat(require('./helpers.js'));
 

--- a/src/lib/grammar.js
+++ b/src/lib/grammar.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
-var XRegExp = require('xregexp').XRegExp;
+var XRegExp = require('xregexp');
 var objectAssign = require('object-assign');
 
 var PSEUDO_CLASSES = {


### PR DESCRIPTION
The old method of importing XRegExp seems to be breaking on the client now with the 3.0.0 release, even though the docs claim it's still valid.  I'll just update to use the simplified `require()`, since it fixes the issue.

