### PR TITLE
Update grammar definitions to support CamelCase breakpoint names.

### DIFF
--- a/src/lib/grammar.js
+++ b/src/lib/grammar.js
@@ -76,7 +76,7 @@ var GRAMMAR = {
     'IMPORTANT'     : '!',
     // https://regex101.com/r/mM2vT9/8
     'NAMED'         : '([\\w$]+(?:(?:-(?!\\-))?\\w*)*)',
-    'BREAKPOINT'    : '--(?<breakPoint>[a-z0-9]+)',
+    'BREAKPOINT'    : '--(?<breakPoint>[a-zA-Z0-9]+)',
     'PSEUDO_CLASS'  : '(?:' + flatten(PSEUDO_CLASSES).join('|') + ')(?![a-z])',
     'PSEUDO_ELEMENT': '(?:' + flatten(PSEUDO_ELEMENTS).join('|') + ')(?![a-z])',
     'PSEUDO_CLASS_SIMPLE'   : ':[a-z]+',


### PR DESCRIPTION
As the title says, this would allow breakpoint definitions to have CamelCase names.