### PR TITLE
Fixing grammar for classes with numbers in their prefix

### DIFF
--- a/src/lib/grammar.js
+++ b/src/lib/grammar.js
@@ -64,7 +64,7 @@ var GRAMMAR = {
     'PARENT'        : '[a-zA-Z][-_a-zA-Z0-9]+?',
     'PARENT_SEP'    : '[>_+]',
     // all characters allowed to be a prop
-    'PROP'          : '[A-Za-z]+',
+    'PROP'          : '[A-Za-z0-9]+',
     // all character allowed to be in values
     'VALUES'        : '[-_,.#$/%0-9a-zA-Z]+',
     'FRACTION'      : '(?<numerator>[0-9]+)\\/(?<denominator>[1-9](?:[0-9]+)?)',

--- a/tests/atomizer.js
+++ b/tests/atomizer.js
@@ -342,7 +342,7 @@ describe('Atomizer()', function () {
         it ('returns css by reading an array of class names', function () {
             var atomizer = new Atomizer();
             var config = {
-                classNames: ['Bd(0)', 'Bd(n)', 'C(red)', 'Cnt(cq):h::b', 'Cnt(oq)::b', 'Px(inh)', 'Trsdu(.3s)', 'sibling:c+D(n)', 'End(0)', 'Ta(start)', 'Ta(end)', 'Bgc(#fff.4)', 'Bgc(#fff)', 'P(55px)', 'H(100%)', 'M(a)', 'test:h>Op(1):h', 'test:h_Op(1):h', 'Op(1)', 'Op(1)!', 'D(n)!', 'C(#333)', 'C(#333):li', 'Mt(-10px)', 'W(1/3)', 'Bgz(45px)']
+                classNames: ['Translate3d(0,0,0)', 'Bd(0)', 'Bd(n)', 'C(red)', 'Cnt(cq):h::b', 'Cnt(oq)::b', 'Px(inh)', 'Trsdu(.3s)', 'sibling:c+D(n)', 'End(0)', 'Ta(start)', 'Ta(end)', 'Bgc(#fff.4)', 'Bgc(#fff)', 'P(55px)', 'H(100%)', 'M(a)', 'test:h>Op(1):h', 'test:h_Op(1):h', 'Op(1)', 'Op(1)!', 'D(n)!', 'C(#333)', 'C(#333):li', 'Mt(-10px)', 'W(1/3)', 'Bgz(45px)']
             };
             var expected = [
                 '.Bd\\(0\\) {',
@@ -417,6 +417,9 @@ describe('Atomizer()', function () {
                 '}',
                 '.Ta\\(end\\) {',
                 '  text-align: right;',
+                '}',
+                '.Translate3d\\(0\\,0\\,0\\) {',
+                '  transform: translate3d(0,0,0);',
                 '}',
                 '.Trsdu\\(\\.3s\\) {',
                 '  transition-duration: .3s;',


### PR DESCRIPTION
`Translate3d(...)` wasn't working property because numbers weren't being allowed in the classname prefix.